### PR TITLE
Composer fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
         "nette/utils": "^3.0 || ^4.0"
     },
     "autoload": {
-        "classmap": [
-            "src/"
-        ]
+        "psr-4": {
+            "Murdej\\TsLinkPhp\\": "src/TsLinkPhp/"
+        }
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "A simple transparent link for calling php methods from typescript.",
     "license": "Apache-2.0",
     "type": "library",
-    "version": "1.1.1",
     "require": {
         "php": ">=8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
         "classmap": [
             "src/"
         ]
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,15 @@
 {
     "name": "murdej/ts-link-php",
     "description": "A simple transparent link for calling php methods from typescript.",
+    "license": "Apache-2.0",
     "type": "library",
     "version": "1.1.1",
-	"license": "Apache-2.0",
     "require": {
         "php": ">=8.0"
     },
-	"autoload": {
-		"classmap": ["src/"]
-	}
+    "autoload": {
+        "classmap": [
+            "src/"
+        ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "Apache-2.0",
     "type": "library",
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.0",
+        "nette/utils": "^3.0 || ^4.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
- Naformátování `composer.json` podle [normalizovaného formátu](https://localheinz.com/articles/2018/01/15/normalizing-composer.json/)
- Odstranění `version` fieldu, protože Composer builduje verze především podle tagů v Gitu ([více info](https://getcomposer.org/doc/articles/versions.md))
- doplnění chybějícího balíčku `nette/utils`, který se v PHP kódu používá jako nepodmíněná závislost,
- změna autoloadingu z `classmap` na PSR-4 (je potřeba mergnout i PR #4 aby to fungovalo dál!!!)