### PR TITLE
Gitignore: Ignore Composer related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+/.idea
+/composer.lock
+/vendor/


### PR DESCRIPTION
- Doplnění souborů a složek, které jsou potřeba pro lokální vývoj, do `.gitignore`, aby se předešlo nežádoucímu zaverzování souborů, které ve výsledném balíčku nemají být.