### PR TITLE
Code style fixes of PHP files

### DIFF
--- a/src/TsLinkPhp/ClassReflection.php
+++ b/src/TsLinkPhp/ClassReflection.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace Murdej\TsLinkPhp;
 
@@ -8,9 +10,8 @@ use ReflectionUnionType;
 
 class ClassReflection
 {
-
-	/** @var ClassReflectionMethod[] */
-	public array $methods = [];
+    /** @var ClassReflectionMethod[] */
+    public array $methods = [];
 
     /** @var string[][] */
     public array $imports = [];
@@ -18,48 +19,50 @@ class ClassReflection
     public string $classShortName;
 
     public function parseClass(string $className)
-	{
-		$refl = new ReflectionClass($className);
+    {
+        $refl = new ReflectionClass($className);
         $this->classShortName = $refl->getShortName();
-		foreach ($refl->getMethods() as $method) {
-			$cms = $method->getAttributes(ClientMethod::class);
-			if (!$cms) continue;
-			$cmi = reset($cms)->newInstance();
-			$crm = new ClassReflectionMethod();
-			$crm->name = $method->name;
-			$crm->params = [];
-			foreach ($method->getParameters() as $parameter) {
-				$crmp = new ClassReflectionMethodParam();
-				$crmp->name = $parameter->name;
-				$crmp->nullable = $parameter->allowsNull();
-				$cmps = $parameter->getAttributes(ClientMethodType::class);
-				if ($cmps) {
-					/** @var ClientMethodType $cmpi */
-					$cmpi = reset($cmps)->newInstance();
-					$crmp->dataType = $cmpi->type;
-				} else {
-					$crmp->dataType = $parameter->getType();
-				}
+        foreach ($refl->getMethods() as $method) {
+            $cms = $method->getAttributes(ClientMethod::class);
+            if (!$cms) {
+                continue;
+            }
+            $cmi = reset($cms)->newInstance();
+            $crm = new ClassReflectionMethod();
+            $crm->name = $method->name;
+            $crm->params = [];
+            foreach ($method->getParameters() as $parameter) {
+                $crmp = new ClassReflectionMethodParam();
+                $crmp->name = $parameter->name;
+                $crmp->nullable = $parameter->allowsNull();
+                $cmps = $parameter->getAttributes(ClientMethodType::class);
+                if ($cmps) {
+                    /** @var ClientMethodType $cmpi */
+                    $cmpi = reset($cmps)->newInstance();
+                    $crmp->dataType = $cmpi->type;
+                } else {
+                    $crmp->dataType = $parameter->getType();
+                }
 
-				$crm->params[$crmp->name] = $crmp;
-			}
+                $crm->params[$crmp->name] = $crmp;
+            }
 
-			$cmps = $method->getAttributes(ClientMethodType::class);
-			$crm->rawResult = $cmi->rawResult;
-			if ($cmi->rawResult) {
-				$crm->returnDataType = 'ByteArray';
-			} elseif ($cmps) {
-				/** @var ClientMethodType $cmpi */
-				$cmpi = reset($cmps)->newInstance();
-				$crm->returnDataType = $cmpi->type;
-			} else {
-				$crm->returnDataType = $method->getReturnType();
-			}
+            $cmps = $method->getAttributes(ClientMethodType::class);
+            $crm->rawResult = $cmi->rawResult;
+            if ($cmi->rawResult) {
+                $crm->returnDataType = 'ByteArray';
+            } elseif ($cmps) {
+                /** @var ClientMethodType $cmpi */
+                $cmpi = reset($cmps)->newInstance();
+                $crm->returnDataType = $cmpi->type;
+            } else {
+                $crm->returnDataType = $method->getReturnType();
+            }
 
-			$this->methods[] = $crm;
+            $this->methods[] = $crm;
 
             $this->getImportsFromAttributes($method->getAttributes(ClientMethodImport::class));
-		}
+        }
 
         $this->getImportsFromAttributes($refl->getAttributes(ClientMethodImport::class));
         /* foreach ($refl->getAttributes(ClientMethodImport::class) as $attribute) {
@@ -70,10 +73,8 @@ class ClassReflection
                 $this->imports[$imp->from][] = $type;
             }
         } */
-
-		// dump($this->methods);
-	}
-
+        // dump($this->methods);
+    }
 
     private function getImportsFromAttributes(array $attributes)
     {
@@ -81,7 +82,9 @@ class ClassReflection
             /** @var ClientMethodImport $imp */
             $imp = $attribute->newInstance();
             foreach ($imp->types as $type) {
-                if (!isset($this->imports[$imp->from])) $this->imports[$imp->from] = [];
+                if (!isset($this->imports[$imp->from])) {
+                    $this->imports[$imp->from] = [];
+                }
                 $this->imports[$imp->from][] = $type;
             }
         }
@@ -89,48 +92,46 @@ class ClassReflection
 
     public function __construct(string|null $className = null)
     {
-        if ($className) $this->parseClass($className);
+        if ($className) {
+            $this->parseClass($className);
+        }
     }
-
 }
 
 class ClassReflectionMethod
 {
+    public string $name;
 
-	public string $name;
+    /** @var ClassReflectionMethodParam[] */
+    public array $params;
 
-	/** @var ClassReflectionMethodParam[] */
-	public array $params;
+    public ReflectionNamedType|ReflectionUnionType|null|string $returnDataType;
 
-	public ReflectionNamedType|ReflectionUnionType|null|string $returnDataType;
-
-	public bool $rawResult = false;
+    public bool $rawResult = false;
 
     public bool $newResult = false;
 
-    public function prepare() {
+    public function prepare()
+    {
         if (is_string($this->returnDataType) && str_starts_with($this->returnDataType, 'new ')) {
             $this->returnDataType = substr($this->returnDataType, 4);
             $this->newResult = true;
         }
     }
 
-	public function getCallOpts(): array
+    public function getCallOpts(): array
     {
-		return [
-			'rawResult' => $this->rawResult,
-		];
-	}
-
+        return [
+            'rawResult' => $this->rawResult,
+        ];
+    }
 }
 
 class ClassReflectionMethodParam
 {
+    public string $name;
 
-	public string $name;
+    public bool $nullable;
 
-	public bool $nullable;
-
-	public ReflectionNamedType|ReflectionUnionType|null|string $dataType;
-
+    public ReflectionNamedType|ReflectionUnionType|null|string $dataType;
 }

--- a/src/TsLinkPhp/ClassReflection.php
+++ b/src/TsLinkPhp/ClassReflection.php
@@ -63,15 +63,6 @@ class ClassReflection
         }
 
         $this->getImportsFromAttributes($refl->getAttributes(ClientMethodImport::class));
-        /* foreach ($refl->getAttributes(ClientMethodImport::class) as $attribute) {
-            /** @var ClientMethodImport $imp * /
-            $imp = $attribute->newInstance();
-            foreach ($imp->types as $type) {
-                if (!isset($this->imports[$imp->from])) $this->imports[$imp->from] = [];
-                $this->imports[$imp->from][] = $type;
-            }
-        } */
-        // dump($this->methods);
     }
 
     private function getImportsFromAttributes(array $attributes)

--- a/src/TsLinkPhp/ClassReflection.php
+++ b/src/TsLinkPhp/ClassReflection.php
@@ -16,7 +16,14 @@ class ClassReflection
 
     public string $classShortName;
 
-    public function parseClass(string $className)
+    public function __construct(?string $className = null)
+    {
+        if ($className) {
+            $this->parseClass($className);
+        }
+    }
+
+    public function parseClass(string $className): void
     {
         $refl = new ReflectionClass($className);
         $this->classShortName = $refl->getShortName();
@@ -65,7 +72,7 @@ class ClassReflection
         $this->getImportsFromAttributes($refl->getAttributes(ClientMethodImport::class));
     }
 
-    private function getImportsFromAttributes(array $attributes)
+    private function getImportsFromAttributes(array $attributes): void
     {
         foreach ($attributes as $attribute) {
             /** @var ClientMethodImport $imp */
@@ -76,13 +83,6 @@ class ClassReflection
                 }
                 $this->imports[$imp->from][] = $type;
             }
-        }
-    }
-
-    public function __construct(string|null $className = null)
-    {
-        if ($className) {
-            $this->parseClass($className);
         }
     }
 }

--- a/src/TsLinkPhp/ClassReflection.php
+++ b/src/TsLinkPhp/ClassReflection.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Murdej\TsLinkPhp;
 
 use ReflectionClass;
-use ReflectionNamedType;
-use ReflectionUnionType;
 
 class ClassReflection
 {
@@ -96,42 +94,4 @@ class ClassReflection
             $this->parseClass($className);
         }
     }
-}
-
-class ClassReflectionMethod
-{
-    public string $name;
-
-    /** @var ClassReflectionMethodParam[] */
-    public array $params;
-
-    public ReflectionNamedType|ReflectionUnionType|null|string $returnDataType;
-
-    public bool $rawResult = false;
-
-    public bool $newResult = false;
-
-    public function prepare()
-    {
-        if (is_string($this->returnDataType) && str_starts_with($this->returnDataType, 'new ')) {
-            $this->returnDataType = substr($this->returnDataType, 4);
-            $this->newResult = true;
-        }
-    }
-
-    public function getCallOpts(): array
-    {
-        return [
-            'rawResult' => $this->rawResult,
-        ];
-    }
-}
-
-class ClassReflectionMethodParam
-{
-    public string $name;
-
-    public bool $nullable;
-
-    public ReflectionNamedType|ReflectionUnionType|null|string $dataType;
 }

--- a/src/TsLinkPhp/ClassReflectionMethod.php
+++ b/src/TsLinkPhp/ClassReflectionMethod.php
@@ -20,7 +20,7 @@ class ClassReflectionMethod
 
     public bool $newResult = false;
 
-    public function prepare()
+    public function prepare(): void
     {
         if (is_string($this->returnDataType) && str_starts_with($this->returnDataType, 'new ')) {
             $this->returnDataType = substr($this->returnDataType, 4);

--- a/src/TsLinkPhp/ClassReflectionMethod.php
+++ b/src/TsLinkPhp/ClassReflectionMethod.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Murdej\TsLinkPhp;
+
+use ReflectionNamedType;
+use ReflectionUnionType;
+
+class ClassReflectionMethod
+{
+    public string $name;
+
+    /** @var ClassReflectionMethodParam[] */
+    public array $params;
+
+    public ReflectionNamedType|ReflectionUnionType|null|string $returnDataType;
+
+    public bool $rawResult = false;
+
+    public bool $newResult = false;
+
+    public function prepare()
+    {
+        if (is_string($this->returnDataType) && str_starts_with($this->returnDataType, 'new ')) {
+            $this->returnDataType = substr($this->returnDataType, 4);
+            $this->newResult = true;
+        }
+    }
+
+    public function getCallOpts(): array
+    {
+        return [
+            'rawResult' => $this->rawResult,
+        ];
+    }
+}

--- a/src/TsLinkPhp/ClassReflectionMethodParam.php
+++ b/src/TsLinkPhp/ClassReflectionMethodParam.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Murdej\TsLinkPhp;
+
+use ReflectionNamedType;
+use ReflectionUnionType;
+
+class ClassReflectionMethodParam
+{
+    public string $name;
+
+    public bool $nullable;
+
+    public ReflectionNamedType|ReflectionUnionType|null|string $dataType;
+}

--- a/src/TsLinkPhp/ClientMethod.php
+++ b/src/TsLinkPhp/ClientMethod.php
@@ -1,18 +1,23 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Murdej\TsLinkPhp;
 
-#[\Attribute]
+use Attribute;
+
+#[Attribute]
 class ClientMethod
 {
-	public bool $rawResult = false;
+    public bool $rawResult = false;
 
-	public function __construct(bool $rawResult = false)
-	{
-		$this->rawResult = $rawResult;
-	}
+    public function __construct(bool $rawResult = false)
+    {
+        $this->rawResult = $rawResult;
+    }
 
-	public function getCallOpts() {
-		return (array)$this;
-	}
+    public function getCallOpts()
+    {
+        return (array)$this;
+    }
 }

--- a/src/TsLinkPhp/ClientMethod.php
+++ b/src/TsLinkPhp/ClientMethod.php
@@ -16,7 +16,7 @@ class ClientMethod
         $this->rawResult = $rawResult;
     }
 
-    public function getCallOpts()
+    public function getCallOpts(): array
     {
         return (array)$this;
     }

--- a/src/TsLinkPhp/ClientMethodImport.php
+++ b/src/TsLinkPhp/ClientMethodImport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Murdej\TsLinkPhp;
 
 use Attribute;

--- a/src/TsLinkPhp/ClientMethodImport.php
+++ b/src/TsLinkPhp/ClientMethodImport.php
@@ -1,17 +1,19 @@
 <?php
 
-
 namespace Murdej\TsLinkPhp;
 
-#[\Attribute]
+use Attribute;
+
+#[Attribute]
 class ClientMethodImport
 {
-	public string $from;
-	public array $types;
+    public string $from;
 
-	public function __construct(string $from, array $types)
-	{
-		$this->from = $from;
-		$this->types = $types;
-	}
+    public array $types;
+
+    public function __construct(string $from, array $types)
+    {
+        $this->from = $from;
+        $this->types = $types;
+    }
 }

--- a/src/TsLinkPhp/ClientMethodType.php
+++ b/src/TsLinkPhp/ClientMethodType.php
@@ -1,22 +1,24 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Murdej\TsLinkPhp;
 
+use Attribute;
 use ReflectionNamedType;
 use ReflectionUnionType;
 
-#[\Attribute]
+#[Attribute]
 class ClientMethodType
 {
-	public ReflectionNamedType|ReflectionUnionType|null|string $type;
+    public ReflectionNamedType|ReflectionUnionType|null|string $type;
 
-	public ?bool $nullable;
+    public ?bool $nullable;
 
-	public function __construct(ReflectionNamedType|ReflectionUnionType|null|string $type, ?bool $nullable = null)
-	{
-		$this->type = $type;
+    public function __construct(ReflectionNamedType|ReflectionUnionType|null|string $type, ?bool $nullable = null)
+    {
+        $this->type = $type;
 
-		$this->nullable = $nullable;
-
-	}
+        $this->nullable = $nullable;
+    }
 }

--- a/src/TsLinkPhp/IContextUpdate.php
+++ b/src/TsLinkPhp/IContextUpdate.php
@@ -4,5 +4,5 @@ namespace Murdej\TsLinkPhp;
 
 interface IContextUpdate
 {
-    function getContextUpdates();
+    public function getContextUpdates();
 }

--- a/src/TsLinkPhp/KtCodeGenerator.php
+++ b/src/TsLinkPhp/KtCodeGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Murdej\TsLinkPhp;
 
 use ReflectionNamedType;

--- a/src/TsLinkPhp/KtCodeGenerator.php
+++ b/src/TsLinkPhp/KtCodeGenerator.php
@@ -7,78 +7,96 @@ use ReflectionUnionType;
 
 class KtCodeGenerator
 {
-	public string $package = "../BaseCL";
+    public string $package = "../BaseCL";
 
-	public string $baseClassName = "BaseCL";
+    public string $baseClassName = "BaseCL";
 
-	public ?string $className = null;
+    public ?string $className = null;
 
-	public ClassReflection $classReflection;
+    public ClassReflection $classReflection;
 
-	public function generateCode() : string
-	{
-		$res = "";
-		$ln = function(string ...$lines) use (&$res) {
-			foreach ($lines as $line)
-				$res .= $line . "\n";
-		};
-		$ln("// GENERATED FILE, DO NOT EDIT");
-		if ($this->baseClassRequire)
-			$ln("import { $this->baseClassName } from \"$this->baseClassRequire\";");
-		$ln("export class $this->className extends $this->baseClassName {");
-		foreach ($this->classReflection->methods as $method) {
-			$m = "\tpublic $method->name(";
-			$f = true;
-			foreach ($method->params as $param)
-			{
-				if ($f) $f = false;
-				else $m .= ", ";
-				$m .= $param->name.": ".$this->phpTypeTpTS($param->dataType, $param->nullable);
-			}
-			$resType = $this->phpTypeTpTS($method->returnDataType, null);
-			$m .= ") : Promise<" . $resType . "> { return this.callMethod(\"$method->name\", arguments, " . json_encode($method->getCallOpts()) . "); }";
-			$ln($m);
-		}
-		$ln("}");
+    /** @noinspection PsalmAdvanceCallableParamsInspection - PhpStorm bug with Closure */
+    public function generateCode(): string
+    {
+        $res = "";
+        $ln = function (string ...$lines) use (&$res) {
+            foreach ($lines as $line) {
+                $res .= $line . "\n";
+            }
+        };
+        $ln("// GENERATED FILE, DO NOT EDIT");
+        if ($this->baseClassRequire) {
+            $ln("import { $this->baseClassName } from \"$this->baseClassRequire\";");
+        }
+        $ln("export class $this->className extends $this->baseClassName {");
+        foreach ($this->classReflection->methods as $method) {
+            $m = "\tpublic $method->name(";
+            $f = true;
+            foreach ($method->params as $param) {
+                if ($f) {
+                    $f = false;
+                } else {
+                    $m .= ", ";
+                }
+                $m .= $param->name . ": " . $this->phpTypeTpTS($param->dataType, $param->nullable);
+            }
+            $resType = $this->phpTypeTpTS($method->returnDataType, null);
+            $m .= ") : Promise<" . $resType . "> { return this.callMethod(\"$method->name\", arguments, "
+                . json_encode($method->getCallOpts())
+                . "); }";
+            $ln($m);
+        }
+        $ln("}");
 
-		return $res;
-	}
+        return $res;
+    }
 
-	public function phpTypeTpTS(ReflectionNamedType|ReflectionUnionType|string|null $dataType, ?bool $nullable) : string
-	{
-		if (!$dataType) return "any";
-		if ($dataType instanceof ReflectionUnionType)
-		{
-			return implode("|", array_map(
-				fn(ReflectionNamedType $dt) => $this->phpTypeTpTS($dt, $nullable),
-				$dataType->getTypes()
-			));
-		}
-		$aliases = [
-			"bool" => "boolean",
-			"int" => "number",
-			"integer" => "number",
-			"double" => "boolean",
-			"float" => "number",
-			"string" => "string",
-			"array" => "any",
-			"object" => "any",
-			"dict" => "Record<number|string|boolean, any>",
-			"list" => "any[]",
-		];
-		$isCustom = is_string($dataType);
-		if ($dataType instanceof \ReflectionNamedType) {
-			$nullable = $dataType->allowsNull();
-			$dataType = $dataType->getName();
-		}
-		if ($dataType && $dataType[0] == "?") {
-			$dataType = substr($dataType, 1);
-			$nullable = true;
-		}
-		if (isset($aliases[$dataType])) $dataType = $aliases[$dataType];
-		else if (!$isCustom) $dataType = "any";
-		if ($nullable) $dataType = $dataType."|null";
+    public function phpTypeTpTS(ReflectionNamedType|ReflectionUnionType|string|null $dataType, ?bool $nullable): string
+    {
+        if (!$dataType) {
+            return "any";
+        }
+        if ($dataType instanceof ReflectionUnionType) {
+            return implode(
+                "|",
+                array_map(
+                    fn(ReflectionNamedType $dt) => $this->phpTypeTpTS($dt, $nullable),
+                    $dataType->getTypes()
+                )
+            );
+        }
+        $aliases = [
+            "bool" => "boolean",
+            "int" => "number",
+            "integer" => "number",
+            "double" => "boolean",
+            "float" => "number",
+            "string" => "string",
+            "array" => "any",
+            "object" => "any",
+            "dict" => "Record<number|string|boolean, any>",
+            "list" => "any[]",
+        ];
+        $isCustom = is_string($dataType);
+        if ($dataType instanceof ReflectionNamedType) {
+            $nullable = $dataType->allowsNull();
+            $dataType = $dataType->getName();
+        }
+        if ($dataType && $dataType[0] == "?") {
+            $dataType = substr($dataType, 1);
+            $nullable = true;
+        }
+        if (isset($aliases[$dataType])) {
+            $dataType = $aliases[$dataType];
+        } else {
+            if (!$isCustom) {
+                $dataType = "any";
+            }
+        }
+        if ($nullable) {
+            $dataType = $dataType . "|null";
+        }
 
-		return $dataType;
-	}
+        return $dataType;
+    }
 }

--- a/src/TsLinkPhp/KtCodeGenerator.php
+++ b/src/TsLinkPhp/KtCodeGenerator.php
@@ -9,8 +9,6 @@ use ReflectionUnionType;
 
 class KtCodeGenerator
 {
-    public string $package = "../BaseCL";
-
     public string $baseClassName = "BaseCL";
 
     public ?string $className = null;

--- a/src/TsLinkPhp/RawData.php
+++ b/src/TsLinkPhp/RawData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Murdej\TsLinkPhp;
 
 use Nette\SmartObject;

--- a/src/TsLinkPhp/RawData.php
+++ b/src/TsLinkPhp/RawData.php
@@ -6,28 +6,27 @@ use Nette\SmartObject;
 
 class RawData
 {
-	use SmartObject;
+    use SmartObject;
 
-	public string $contentType = "application/octet-stream";
+    public string $contentType = "application/octet-stream";
 
-	public mixed $data = null;
+    public mixed $data = null;
 
-	public ?string $filePath = null;
+    public ?string $filePath = null;
 
-	public static function filePath(string $filePath) : RawData
-	{
-		$res = new RawData();
-		$res->filePath = $filePath;
+    public static function filePath(string $filePath): RawData
+    {
+        $res = new RawData();
+        $res->filePath = $filePath;
 
-		return $res;
-	}
+        return $res;
+    }
 
-	public static function data(mixed $data) : RawData
-	{
-		$res = new RawData();
-		$res->data = $data;
+    public static function data(mixed $data): RawData
+    {
+        $res = new RawData();
+        $res->data = $data;
 
-		return $res;
-	}
-
+        return $res;
+    }
 }

--- a/src/TsLinkPhp/RawData.php
+++ b/src/TsLinkPhp/RawData.php
@@ -16,17 +16,17 @@ class RawData
 
     public ?string $filePath = null;
 
-    public static function filePath(string $filePath): RawData
+    public static function filePath(string $filePath): self
     {
-        $res = new RawData();
+        $res = new self();
         $res->filePath = $filePath;
 
         return $res;
     }
 
-    public static function data(mixed $data): RawData
+    public static function data(mixed $data): self
     {
-        $res = new RawData();
+        $res = new self();
         $res->data = $data;
 
         return $res;

--- a/src/TsLinkPhp/Response.php
+++ b/src/TsLinkPhp/Response.php
@@ -52,7 +52,6 @@ class Response implements JsonSerializable
     public function getTextContent(): ?string
     {
         return json_encode($this);
-        // return Json::encode($this);
     }
 
     public function __toString(): string

--- a/src/TsLinkPhp/Response.php
+++ b/src/TsLinkPhp/Response.php
@@ -1,56 +1,62 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Murdej\TsLinkPhp;
 
 use Exception;
 use JsonSerializable;
-use Nette\Utils\Json;
 
 class Response implements JsonSerializable
 {
-	public Exception|null $exception = null;
+    public Exception|null $exception = null;
 
-	public mixed $response = null;
+    public mixed $response = null;
 
     public ?array $context = null;
 
-	/**
-	 * @return mixed
-	 */
-	public function jsonSerialize()
-	{
-		$res = [ "status" => $this->exception ? "exception" : "ok" ];
-		if ($this->exception) $res["exception"] = $this->exception->__toString();
-		else $res["response"] = $this->response;
-        if ($this->context) $res["context"] = $this->context;
-		return $res;
-	}
+    /**
+     * @return mixed
+     */
+    public function jsonSerialize()
+    {
+        $res = ["status" => $this->exception ? "exception" : "ok"];
+        if ($this->exception) {
+            $res["exception"] = $this->exception->__toString();
+        } else {
+            $res["response"] = $this->response;
+        }
+        if ($this->context) {
+            $res["context"] = $this->context;
+        }
+        return $res;
+    }
 
-	public function getRaw() : ?RawData
-	{
-		return $this->response instanceof RawData ? $this->response : null;
-	}
+    public function getRaw(): ?RawData
+    {
+        return $this->response instanceof RawData ? $this->response : null;
+    }
 
-	public function getFilePath() : ?string
-	{
-		$raw = $this->getRaw();
-		return ($raw && $raw->filePath) ? $raw->filePath : null;
-	}
+    public function getFilePath(): ?string
+    {
+        $raw = $this->getRaw();
+        return ($raw && $raw->filePath) ? $raw->filePath : null;
+    }
 
-	public function getContentType() : string
-	{
-		$raw = $this->getRaw();
-		return $raw ? $raw->contentType : "application/json";
-	}
+    public function getContentType(): string
+    {
+        $raw = $this->getRaw();
+        return $raw ? $raw->contentType : "application/json";
+    }
 
-	public function getTextContent() : ?string
-	{
-		return json_encode($this);
+    public function getTextContent(): ?string
+    {
+        return json_encode($this);
         // return Json::encode($this);
-	}
+    }
 
-	public function __toString() : string
-	{
-		return json_encode($this);
-	}
+    public function __toString(): string
+    {
+        return json_encode($this);
+    }
 }

--- a/src/TsLinkPhp/Response.php
+++ b/src/TsLinkPhp/Response.php
@@ -15,20 +15,20 @@ class Response implements JsonSerializable
 
     public ?array $context = null;
 
-    /**
-     * @return mixed
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $res = ["status" => $this->exception ? "exception" : "ok"];
+
         if ($this->exception) {
-            $res["exception"] = $this->exception->__toString();
+            $res["exception"] = (string)$this->exception;
         } else {
             $res["response"] = $this->response;
         }
+
         if ($this->context) {
             $res["context"] = $this->context;
         }
+
         return $res;
     }
 
@@ -40,22 +40,22 @@ class Response implements JsonSerializable
     public function getFilePath(): ?string
     {
         $raw = $this->getRaw();
-        return ($raw && $raw->filePath) ? $raw->filePath : null;
+        return $raw->filePath ?? null;
     }
 
     public function getContentType(): string
     {
         $raw = $this->getRaw();
-        return $raw ? $raw->contentType : "application/json";
+        return $raw->contentType ?? "application/json";
     }
 
     public function getTextContent(): ?string
     {
-        return json_encode($this);
+        return json_encode($this, JSON_THROW_ON_ERROR);
     }
 
     public function __toString(): string
     {
-        return json_encode($this);
+        return $this->getTextContent();
     }
 }

--- a/src/TsLinkPhp/TsCodeGenerator.php
+++ b/src/TsLinkPhp/TsCodeGenerator.php
@@ -7,9 +7,9 @@ use ReflectionUnionType;
 
 class TsCodeGenerator
 {
-	public ?string $baseClassRequire = null; //"../BaseCL";
+    public ?string $baseClassRequire = null; //"../BaseCL";
 
-	public string $baseClassName = "BaseCL";
+    public string $baseClassName = "BaseCL";
 
     public string $baseImportPath = "../";
 
@@ -17,7 +17,7 @@ class TsCodeGenerator
      * @var string|null
      * @deprecated Use add method
      */
-	public ?string $className = null;
+    public ?string $className = null;
 
     /**
      * @var string|null
@@ -29,20 +29,12 @@ class TsCodeGenerator
      * @var string|null
      * @deprecated Use add method
      */
-	public ?ClassReflection $classReflection = null;
+    public ?ClassReflection $classReflection = null;
 
     /**
      * @var TsCodeGeneratorSource[]
      */
     protected array $sources = [];
-
-    /**
-     * @param string|ClassReflection $classDef Class name or reflection
-     * @param string|null $endpoint Endpoint, optional
-     * @param string|null $className Name of typescript class or null for detection
-     * @return void
-     * Add class to generation
-     */
 
     /**
      * @var bool Use JS modules, add export to generated classes
@@ -54,6 +46,13 @@ class TsCodeGenerator
      */
     public string $format = "ts";
 
+    /**
+     * @param string|ClassReflection $classDef Class name or reflection
+     * @param string|null $endpoint Endpoint, optional
+     * @param string|null $className Name of typescript class or null for detection
+     * @return void
+     * Add class to generation
+     */
     public function add(string|ClassReflection $classDef, string|null $endpoint = null, ?string $className = null): void
     {
         require_once __DIR__ . '/TsCodeGeneratorSource.php';
@@ -63,25 +62,28 @@ class TsCodeGenerator
     /**
      * @return string
      * Generates typescript code.
+     * @noinspection PsalmAdvanceCallableParamsInspection - PhpStorm bug with Closure
      */
-	public function generateCode() : string
-	{
+    public function generateCode(): string
+    {
         /**
          * @var TsCodeGeneratorSource[] $sources
          */
         $sources = array_merge(
-            $this->classReflection ? [ new ClassReflection($this->classReflection, $this->url) ] : [],
+            $this->classReflection ? [new ClassReflection($this->classReflection, $this->url)] : [],
             $this->sources
         );
-		$res = "";
-		$ln = function(string ...$lines) use (&$res) {
-			foreach ($lines as $line)
-				$res .= $line . "\n";
-		};
-		$ln("// GENERATED FILE, DO NOT EDIT");
+        $res = "";
+        $ln = function (string ...$lines) use (&$res) {
+            foreach ($lines as $line) {
+                $res .= $line . "\n";
+            }
+        };
+        $ln("// GENERATED FILE, DO NOT EDIT");
 
-		if ($this->baseClassRequire)
-			$ln("import { $this->baseClassName } from \"$this->baseClassRequire\";");
+        if ($this->baseClassRequire) {
+            $ln("import { $this->baseClassName } from \"$this->baseClassRequire\";");
+        }
 
         $imports = [];
         foreach ($sources as $source) {
@@ -93,84 +95,105 @@ class TsCodeGenerator
             }
         }
         foreach ($imports as $file => $classes) {
-            $ln("import { " . implode(', ', array_unique($classes)) . " } from \"" . $this->baseImportPath . $file . "\";");
+            $ln(
+                "import { "
+                . implode(', ', array_unique($classes))
+                . " } from \"" . $this->baseImportPath . $file . "\";"
+            );
         }
 
         $isTs = $this->format == "ts";
 
         if (!$this->baseClassRequire) {
-            $bsrc = file_get_contents(__DIR__ . '/BaseCL.'.($isTs ? 'ts' : 'js'));
+            $bsrc = file_get_contents(__DIR__ . '/BaseCL.' . ($isTs ? 'ts' : 'js'));
             if (!$this->useJsModules) {
                 $bsrc = str_replace('export class BaseCL', 'class BaseCL', $bsrc);
             }
             $ln($bsrc);
         }
 
-        foreach ($sources as $source)
-        {
-            $ln(($this->useJsModules ? "export " : "")."class $source->className extends $this->baseClassName {");
+        foreach ($sources as $source) {
+            $ln(($this->useJsModules ? "export " : "") . "class $source->className extends $this->baseClassName {");
             if ($source->endpoint) {
-                $ln("\t" . 'constructor(url'
+                $ln(
+                    "\t" . 'constructor(url'
                     . ($isTs ? ":string" : '')
-                    . '="' . $source->endpoint . '") { super(url); }');
+                    . '="' . $source->endpoint . '") { super(url); }'
+                );
             }
             foreach ($source->classReflection->methods as $method) {
                 $method->prepare();
                 $m = "\t" . ($isTs ? "public " : '') . "$method->name(";
                 $f = true;
                 foreach ($method->params as $param) {
-                    if ($f) $f = false;
-                    else $m .= ", ";
+                    if ($f) {
+                        $f = false;
+                    } else {
+                        $m .= ", ";
+                    }
                     $m .= $param->name . ($isTs ? ": " . $this->phpTypeTpTS($param->dataType, $param->nullable) : "");
                 }
                 $resType = $this->phpTypeTpTS($method->returnDataType, null);
-                $m .= ") " . ($isTs ? ": Promise<" . $resType . ">" : "") . " { return this.callMethod(\"$method->name\", arguments, "
+                $m .= ") "
+                    . ($isTs ? ": Promise<" . $resType . ">" : "")
+                    . " { return this.callMethod(\"$method->name\", arguments, "
                     . json_encode($method->getCallOpts())
                     . ($method->newResult ? ', ' . $method->returnDataType : '')
                     . "); }";
                 $ln($m);
             }
         }
-		$ln("}");
+        $ln("}");
 
-		return $res;
-	}
+        return $res;
+    }
 
-	public function phpTypeTpTS(ReflectionNamedType|ReflectionUnionType|string|null $dataType, ?bool $nullable) : string
-	{
-		if (!$dataType) return "any";
-		if ($dataType instanceof ReflectionUnionType)
-		{
-			return implode("|", array_map(
-				fn(ReflectionNamedType $dt) => $this->phpTypeTpTS($dt, $nullable),
-				$dataType->getTypes()
-			));
-		}
-		$aliases = [
-			"bool" => "boolean",
-			"int" => "number",
-			"integer" => "number",
-			"double" => "number",
-			"float" => "number",
-			"string" => "string",
-			"array" => "any",
-			"object" => "any",
-			"dict" => "Record<number|string|boolean, any>",
-			"list" => "any[]",
-		];
-		$isCustom = is_string($dataType);
-		if ($dataType instanceof \ReflectionNamedType) {
-			$nullable = $dataType->allowsNull();
-			$dataType = $dataType->getName();
-		}
-		if ($dataType && $dataType[0] == "?") {
-			$dataType = substr($dataType, 1);
-			$nullable = true;
-		}
-		if (isset($aliases[$dataType])) $dataType = $aliases[$dataType];
-		else if (!$isCustom) $dataType = "any";
-		if ($nullable) $dataType = $dataType."|null";
+    public function phpTypeTpTS(ReflectionNamedType|ReflectionUnionType|string|null $dataType, ?bool $nullable): string
+    {
+        if (!$dataType) {
+            return "any";
+        }
+        if ($dataType instanceof ReflectionUnionType) {
+            return implode(
+                "|",
+                array_map(
+                    fn(ReflectionNamedType $dt) => $this->phpTypeTpTS($dt, $nullable),
+                    $dataType->getTypes()
+                )
+            );
+        }
+        $aliases = [
+            "bool" => "boolean",
+            "int" => "number",
+            "integer" => "number",
+            "double" => "number",
+            "float" => "number",
+            "string" => "string",
+            "array" => "any",
+            "object" => "any",
+            "dict" => "Record<number|string|boolean, any>",
+            "list" => "any[]",
+        ];
+        $isCustom = is_string($dataType);
+        if ($dataType instanceof ReflectionNamedType) {
+            $nullable = $dataType->allowsNull();
+            $dataType = $dataType->getName();
+        }
+        if ($dataType && $dataType[0] == "?") {
+            $dataType = substr($dataType, 1);
+            $nullable = true;
+        }
+        if (isset($aliases[$dataType])) {
+            $dataType = $aliases[$dataType];
+        } else {
+            if (!$isCustom) {
+                $dataType = "any";
+            }
+        }
+        if ($nullable) {
+            $dataType = $dataType . "|null";
+        }
 
-		return $dataType;
-	}
+        return $dataType;
+    }
 }

--- a/src/TsLinkPhp/TsCodeGenerator.php
+++ b/src/TsLinkPhp/TsCodeGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Murdej\TsLinkPhp;
 
 use ReflectionNamedType;

--- a/src/TsLinkPhp/TsCodeGenerator.php
+++ b/src/TsLinkPhp/TsCodeGenerator.php
@@ -9,7 +9,7 @@ use ReflectionUnionType;
 
 class TsCodeGenerator
 {
-    public ?string $baseClassRequire = null; //"../BaseCL";
+    public ?string $baseClassRequire = null;
 
     public string $baseClassName = "BaseCL";
 

--- a/src/TsLinkPhp/TsCodeGenerator.php
+++ b/src/TsLinkPhp/TsCodeGenerator.php
@@ -15,13 +15,6 @@ class TsCodeGenerator
 
     public string $baseImportPath = "../";
 
-    /**
-     * @var string|null
-     * @deprecated Use add method
-     */
-    public ?string $className = null;
-
-    /**
      * @var string|null
      * @deprecated Use add method
      */
@@ -72,7 +65,7 @@ class TsCodeGenerator
          * @var TsCodeGeneratorSource[] $sources
          */
         $sources = array_merge(
-            $this->classReflection ? [new ClassReflection($this->classReflection, $this->url)] : [],
+            $this->classReflection ? [new ClassReflection($this->classReflection)] : [],
             $this->sources
         );
         $res = "";

--- a/src/TsLinkPhp/TsCodeGeneratorSource.php
+++ b/src/TsLinkPhp/TsCodeGeneratorSource.php
@@ -10,19 +10,14 @@ class TsCodeGeneratorSource
 
     public ClassReflection $classReflection;
 
-    /**
-     * @param ClassReflection|string $classDef
-     */
     public function __construct(
-        $classDef,
+        ClassReflection|string $classDef,
         public ?string $endpoint = null,
         ?string $className = null
     ) {
         $this->classReflection = is_string($classDef)
             ? new ClassReflection($classDef)
             : $classDef;
-        $this->className = ($className === null)
-            ? $this->classReflection->classShortName
-            : $className;
+        $this->className = $className ?? $this->classReflection->classShortName;
     }
 }

--- a/src/TsLinkPhp/TsCodeGeneratorSource.php
+++ b/src/TsLinkPhp/TsCodeGeneratorSource.php
@@ -12,7 +12,6 @@ class TsCodeGeneratorSource
 
     /**
      * @param ClassReflection|string $classDef
-     * @param string|null $endpoint
      */
     public function __construct(
         $classDef,

--- a/src/TsLinkPhp/TsCodeGeneratorSource.php
+++ b/src/TsLinkPhp/TsCodeGeneratorSource.php
@@ -6,6 +6,8 @@ class TsCodeGeneratorSource
 {
     public string $className;
 
+    public ClassReflection $classReflection;
+
     /**
      * @param ClassReflection|string $classDef
      * @param string|null $endpoint
@@ -14,8 +16,7 @@ class TsCodeGeneratorSource
         $classDef,
         public ?string $endpoint = null,
         ?string $className = null
-    )
-    {
+    ) {
         $this->classReflection = is_string($classDef)
             ? new ClassReflection($classDef)
             : $classDef;
@@ -23,6 +24,4 @@ class TsCodeGeneratorSource
             ? $this->classReflection->classShortName
             : $className;
     }
-
-    public ClassReflection $classReflection;
 }

--- a/src/TsLinkPhp/TsCodeGeneratorSource.php
+++ b/src/TsLinkPhp/TsCodeGeneratorSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Murdej\TsLinkPhp;
 
 class TsCodeGeneratorSource

--- a/src/TsLinkPhp/TsLink.php
+++ b/src/TsLinkPhp/TsLink.php
@@ -1,49 +1,61 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Murdej\TsLinkPhp;
 
+use Closure;
+use Throwable;
+
 class TsLink
 {
-	public ClassReflection $classReflection;
+    public ClassReflection $classReflection;
 
-	public object $service;
+    public object $service;
 
-	public bool $sendException = true;
+    public bool $sendException = true;
 
-	public function __construct(object $service)
-	{
-		$this->service = $service;
-	}
+    public Closure|null $onError = null;
 
-    public \Closure|null $onError = null;
+    public function __construct(object $service)
+    {
+        $this->service = $service;
+    }
 
-	public function processRequest(string $src) : Response
-	{
-		$res = new Response();
-		try {
-			$srcStruct = json_decode($src, true);
-			$methodName = $srcStruct["name"];
-			$context = $srcStruct["context"];
-			if ($context && isset($this->service->context)) {
-				foreach ($context as $k => $v)
-					if (is_array($this->service->context))
-						$this->service->context[$k] = $v;
-					else
-						$this->service->context->$k = $v;
-			}
-			$pars = $srcStruct["pars"];
-			$res->response = $this->service->$methodName(...$pars);
-            if ($this->service instanceof IContextUpdate)
+    public function processRequest(string $src): Response
+    {
+        $res = new Response();
+        try {
+            $srcStruct = json_decode($src, true);
+            $methodName = $srcStruct["name"];
+            $context = $srcStruct["context"];
+            if ($context && isset($this->service->context)) {
+                foreach ($context as $k => $v) {
+                    if (is_array($this->service->context)) {
+                        $this->service->context[$k] = $v;
+                    } else {
+                        $this->service->context->$k = $v;
+                    }
+                }
+            }
+            $pars = $srcStruct["pars"];
+            $res->response = $this->service->$methodName(...$pars);
+            if ($this->service instanceof IContextUpdate) {
                 $res->context = $this->service->getContextUpdates();
-		} catch (\Throwable $exception) {
-            if ($this->onError) ($this->onError)($src, $exception);
-			if ($this->sendException) throw $exception;
-			$res->exception = $exception;
-		}
+            }
+        } catch (Throwable $exception) {
+            if ($this->onError) {
+                ($this->onError)($src, $exception);
+            }
+            if ($this->sendException) {
+                throw $exception;
+            }
+            $res->exception = $exception;
+        }
 
-		return $res;
-		/* $jsonS = json_encode($res, JSON_PRETTY_PRINT);
+        return $res;
+        /* $jsonS = json_encode($res, JSON_PRETTY_PRINT);
 
-		return $jsonS; */
-	}
+        return $jsonS; */
+    }
 }

--- a/src/TsLinkPhp/TsLink.php
+++ b/src/TsLinkPhp/TsLink.php
@@ -24,7 +24,7 @@ class TsLink
     {
         $res = new Response();
         try {
-            $srcStruct = json_decode($src, true);
+            $srcStruct = json_decode($src, true, 512, JSON_THROW_ON_ERROR);
             $methodName = $srcStruct["name"];
             $context = $srcStruct["context"];
             if ($context && isset($this->service->context)) {

--- a/src/TsLinkPhp/TsLink.php
+++ b/src/TsLinkPhp/TsLink.php
@@ -9,8 +9,6 @@ use Throwable;
 
 class TsLink
 {
-    public ClassReflection $classReflection;
-
     public object $service;
 
     public bool $sendException = true;

--- a/src/TsLinkPhp/TsLink.php
+++ b/src/TsLinkPhp/TsLink.php
@@ -54,8 +54,5 @@ class TsLink
         }
 
         return $res;
-        /* $jsonS = json_encode($res, JSON_PRETTY_PRINT);
-
-        return $jsonS; */
     }
 }


### PR DESCRIPTION
Posrupné vylepšení PHP kódu bez změny jeho sématiky:

- sjednocení formátování PHP na PSR-12,
- oprava souborové struktury podle PSR-4,
- odstranění mrtvého kódu a zbytečných komentářů,
- doplnění `strict_types` do všech souborů,
- doplnění typů a dalších pomocných atributů kódu,
- úprava strukturování kódu pro zlepšení jeho čitelnosti

Pozn.: Úprava se netýká JS a TS souborů.